### PR TITLE
Updates to the 'Copy the Character' functionality

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -68,7 +68,7 @@
                         <h2>Apply it</h2>
                         <dl>
                             <dt>Copy the character</dt>
-                            <dd class="copy-it"><button class="button-copy" id="copy-mdash" data-clipboard-text="&mdash;"><span class="dash">&mdash;</span></button><span class="copied">&#10004;</span></dd>
+                            <dd class="copy-it"><button class="button-copy" id="copy-mdash" data-clipboard-text="&mdash;" data-character-name="emdash"><span class="dash">&mdash;</span></button><span class="message"></span><span class="dash selection-copy">&mdash;</span></dd>
 
                             <dt>Mac Keyboard</dt>
                             <dd>
@@ -116,7 +116,7 @@
                         <h2>Apply it</h2>
                         <dl>
                             <dt>Copy the character</dt>
-                            <dd class="copy-it"><button class="button-copy" id="copy-ndash" data-clipboard-text="&ndash;">&ndash;</button><span class="copied">&#10004;</span></dd>
+                            <dd class="copy-it"><button class="button-copy" id="copy-ndash" data-clipboard-text="&ndash;" data-character-name="endash">&ndash;</button><span class="message"></span><span class="selection-copy">&ndash;</span></dd>
 
                             <dt>Mac Keyboard</dt>
                             <dd>
@@ -162,7 +162,7 @@
                         <h2>Apply it</h2>
                         <dl>
                             <dt>Copy the character</dt>
-                            <dd class="copy-it"><button class="button-copy" id="copy-hyphen" data-clipboard-text="-">-</button><span class="copied">&#10004;</span></dd>
+                            <dd class="copy-it"><button class="button-copy" id="copy-hyphen" data-clipboard-text="-" data-character-name="hyphen">-</button><span class="message"></span><span class="selection-copy">-</span></dd>
 
                             <dt>Mac Keyboard</dt>
                             <dd><span class="key" title="Hyphen">-</span></dd>
@@ -202,7 +202,7 @@
         <!-- bower:js -->
         <script src="/bower_components/modernizr/modernizr.js"></script>
         <script src="/bower_components/jquery/dist/jquery.js"></script>
-        <script src="/bower_components/zeroclipboard/dist/ZeroClipboard.js"></script>
+        <script src="/bower_components/clipboard/dist/clipboard.js"></script>
         <!-- endbower -->
         <!-- endbuild -->
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -16,36 +16,34 @@ $(function($){
     });
 
     // Clipboard Stuff
-    var confirm = function (fragment) {
-        var $el = $('#copy-' + fragment + ' ~ .copied');
-        $el.addClass('show');
-        window.setTimeout(function () {
-            $el.removeClass('show');
-        }, 100)
-    };
-
-    var mdash = new ZeroClipboard( document.getElementById('copy-mdash') );
-    mdash.on( 'ready', function() {
-        mdash.on( 'aftercopy', function() {
-            confirm('mdash');
-            _gs('event', 'copied emdash');
+    var showMessage = function ($selector, message) {
+        $selector.text(message);
+        $selector.fadeToggle(500, function () {
+            $(this).fadeToggle(4000, function () {
+                $selector.text('');
+            });
         });
+    }
+
+    var clipboard = new Clipboard('.button-copy');
+
+    clipboard.on('success', function(e) {
+        var $message = $(e.trigger).next('.message');
+        showMessage($message, 'Copied!');
+
+        var characterName = $(e.trigger).attr('data-character-name');
+        _gs('event', 'Automatically copied ' + characterName);
+
+        e.clearSelection();
     });
 
-    var ndash = new ZeroClipboard( document.getElementById('copy-ndash') );
-    ndash.on( 'ready', function() {
-        ndash.on( 'aftercopy', function() {
-            confirm('ndash');
-            _gs('event', 'copied endash');
-        });
-    });
+    clipboard.on('error', function(e) {
+        var $message = $(e.trigger).next('.message');
+        showMessage($message, 'Control + C to copy');
 
-    var hyphen = new ZeroClipboard( document.getElementById('copy-hyphen') );
-    hyphen.on( 'ready', function() {
-        hyphen.on( 'aftercopy', function() {
-            confirm('hyphen');
-            _gs('event', 'copied hyphen');
-        });
+        var characterName = $(e.trigger).attr('data-character-name');
+        _gs('event', 'Failed to manually copy ' + characterName);
+
     });
 
     $(document).on('click', 'a[href^="#"]', function (e) {

--- a/app/styles/modules/_copy-it.scss
+++ b/app/styles/modules/_copy-it.scss
@@ -2,16 +2,12 @@
     position: relative;
     width: auto;
 
-    .touch & {
-        button {
-            display: none;
-        }
+    .touch & button {
+        display: none;
     }
 
-    .no-touch & {
-        .selection-copy {
-            display: none;
-        }
+    .no-touch & .selection-copy {
+        display: none;
     }
 
     .button-copy {

--- a/app/styles/modules/_copy-it.scss
+++ b/app/styles/modules/_copy-it.scss
@@ -2,6 +2,18 @@
     position: relative;
     width: auto;
 
+    .touch & {
+        button {
+            display: none;
+        }
+    }
+
+    .no-touch & {
+        .selection-copy {
+            display: none;
+        }
+    }
+
     .button-copy {
         @extend .button;
         background-color: $gray-light;
@@ -13,18 +25,19 @@
         }
     }
 
-    .copied {
+    .selection-copy {
+        font-size: 2em;
+        padding: 0 0.25em;
+        position: relative;
+    }
+
+    .message {
         position: absolute;
         top: 0;
-        left: 2.75em;
-        font-size: 1.5em;
-        line-height: 1.75em;
+        left: 65px;
+        font-size: 16px;
+        line-height: 47px;
         color: $gray-dark;
-        opacity: 0;
-        transition: 3s opacity ease-in;
-        &.show {
-            opacity: 1;
-            transition: 0.1s opacity ease-out;
-        }
+        display: none;
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "jquery": "~2.1.4",
     "modernizr": "~2.8.3",
     "neat": "~1.7.2",
-    "zeroclipboard": "~2.2.0"
+    "clipboard": "~1.4.0"
   }
 }


### PR DESCRIPTION
- Replaced the Zeroclipboard library with Clipboard.js
- Better fallbacks for mobile browsers (replaces button with text that can be more easily selected for manual copy
- Fallback for Safari which isn't supported by the new library to select the text instead and prompt for pressing Control + C
