### PR TITLE
General cleanup and performance tweaks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,10 +32,6 @@ module.exports = function (grunt) {
 
     // Watches files for changes and runs tasks based on the changed files
     watch: {
-      bower: {
-        files: ['bower.json'],
-        tasks: ['wiredep']
-      },
       babel: {
         files: ['<%= config.app %>/scripts/{,*/}*.js'],
         tasks: ['babel:dist']
@@ -151,18 +147,6 @@ module.exports = function (grunt) {
       }
     },
 
-    // Automatically inject Bower components into the HTML file
-    wiredep: {
-      app: {
-        src: ['<%= config.app %>/index.html'],
-        ignorePath: /^(\.\.\/)*\.\./
-      },
-      sass: {
-        src: ['<%= config.app %>/styles/{,*/}*.{scss,sass}'],
-        ignorePath: /^(\.\.\/)+/
-      }
-    },
-
     // Renames files for browser caching purposes
     filerev: {
       dist: {
@@ -259,14 +243,6 @@ module.exports = function (grunt) {
             '{,*/}*.html',
             'styles/fonts/{,*/}*.*'
           ]
-      }, {
-          expand: true,
-          dot: true,
-          cwd: 'bower_components/zeroclipboard/dist',
-          dest: '<%= config.dist %>/scripts',
-          src: [
-              '*.swf'
-          ]
       }]
       }
     },
@@ -312,7 +288,6 @@ module.exports = function (grunt) {
 
     grunt.task.run([
       'clean:server',
-      'wiredep',
       'concurrent:server',
       'browserSync:livereload',
       'watch'
@@ -326,7 +301,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build', [
     'clean:dist',
-    'wiredep',
     'useminPrepare',
     'concurrent:dist',
     'concat',

--- a/app/index.html
+++ b/app/index.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
         <!-- build:js scripts/vendor/modernizr.js -->
-        <script src="bower_components/modernizr/modernizr.js"></script>
+        <script src="bower_components/modernizr/modernizr.js" async></script>
         <!-- endbuild -->
         <link href='http://fonts.googleapis.com/css?family=Lora:400,700,700italic' rel='stylesheet' type='text/css'>
     </head>

--- a/app/index.html
+++ b/app/index.html
@@ -11,10 +11,6 @@
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
         <link rel="author" href="humans.txt" />
 
-        <!-- build:css(.) styles/vendor.css -->
-        <!-- bower:css -->
-        <!-- endbower -->
-        <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
@@ -24,10 +20,6 @@
         <link href='http://fonts.googleapis.com/css?family=Lora:400,700,700italic' rel='stylesheet' type='text/css'>
     </head>
     <body>
-        <!--[if lt IE 10]>
-          <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-        <![endif]-->
-
         <header>
             <div class="content sitenav">
                 <nav class="sitenav-text">
@@ -198,18 +190,6 @@
             </div>
         </footer>
 
-        <!-- build:js(.) scripts/vendor.js -->
-        <!-- bower:js -->
-        <script src="/bower_components/modernizr/modernizr.js"></script>
-        <script src="/bower_components/jquery/dist/jquery.js"></script>
-        <script src="/bower_components/clipboard/dist/clipboard.js"></script>
-        <!-- endbower -->
-        <!-- endbuild -->
-
-        <!-- build:js scripts/main.js -->
-        <script src="scripts/main.js"></script>
-        <!-- endbuild -->
-
         <script>
           !function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(
           arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];
@@ -218,6 +198,12 @@
 
           _gs('GSN-347462-J');
         </script>
+
+        <!-- build:js scripts/main.js -->
+        <script src="/bower_components/jquery/dist/jquery.js"></script>
+        <script src="/bower_components/clipboard/dist/clipboard.js"></script>
+        <script src="scripts/main.js"></script>
+        <!-- endbuild -->
 
     </body>
 </html>

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,6 +1,9 @@
 // jshint devel:true
+/*global jQuery Clipboard _gs*/
 
-$(function($){
+(function($, Clipboard, _gs){
+    'use strict';
+
     // Keeps the two nav items' hover states in sync
     $('.js-hover-trigger').each(function (i, e) {
         var href = $(e).attr('href');
@@ -23,7 +26,7 @@ $(function($){
                 $selector.text('');
             });
         });
-    }
+    };
 
     var clipboard = new Clipboard('.button-copy');
 
@@ -60,4 +63,4 @@ $(function($){
     });
 
 
-});
+})(jQuery, Clipboard, _gs);

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -24,10 +24,3 @@
         font-size: 1.4rem;
     }
 }
-
-.browsehappy {
-    margin: 0.2em 0;
-    background: #ccc;
-    color: #000;
-    padding: 0.2em 0;
-}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "grunt-sass": "^1.0.0",
     "grunt-svgmin": "^2.0.1",
     "grunt-usemin": "^3.0.0",
-    "grunt-wiredep": "^2.0.0",
     "jit-grunt": "^0.9.1",
     "time-grunt": "^1.1.0"
   },


### PR DESCRIPTION
- Removed wiredep: was messing up the custom modernizr build and I wasn't really using it anyway
- Removed copy task for old ZeroClipboard flash library
- Removed BrowseHappy block
- Stopped empty vendor.css from being generated
- Made modernizr load asynchronously
- Bundled vendor and main javascript files into one
- Fixed a few linting warnings
